### PR TITLE
fix(kubeconfig): remove trailing slash from Rancher URL to prevent do…

### DIFF
--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -82,10 +82,12 @@ func (c *Kubeconfig) UpdateTokenByName(clusterID, clusterName, token, rancherURL
 	// If auto-create is enabled, create new cluster, context, and user entries
 	if autoCreate {
 		// Create new cluster entry with correct server URL using cluster ID
+		// Remove trailing slash from rancherURL to avoid double slashes
+		cleanURL := strings.TrimSuffix(rancherURL, "/")
 		newCluster := ConfigCluster{
 			Name: clusterName,
 			Cluster: map[string]any{
-				"server": rancherURL + "/k8s/clusters/" + clusterID,
+				"server": cleanURL + "/k8s/clusters/" + clusterID,
 			},
 		}
 		c.Clusters = append(c.Clusters, newCluster)

--- a/internal/kubeconfig/kubeconfig_test.go
+++ b/internal/kubeconfig/kubeconfig_test.go
@@ -462,7 +462,7 @@ func TestSaveKubeconfig_YAMLSerialization(t *testing.T) {
 }
 
 // ============================================================================
-// UpdateTokenByName Tests (P0)
+// UpdateTokenByName Tests
 // ============================================================================
 
 // TestUpdateTokenByName_ExistingUser tests updating an existing user's token
@@ -575,7 +575,7 @@ func TestUpdateTokenByName_RancherURLFormatting(t *testing.T) {
 			name:        "URL with trailing slash",
 			rancherURL:  "https://rancher.example.com/",
 			clusterID:   "c-abc123",
-			expectedURL: "https://rancher.example.com//k8s/clusters/c-abc123",
+			expectedURL: "https://rancher.example.com/k8s/clusters/c-abc123",
 		},
 		{
 			name:        "HTTP URL",


### PR DESCRIPTION
fix(kubeconfig): remove trailing slash from Rancher URL to prevent double slashes