### PR TITLE
Standardize log format to pipe-delimited key=value style

### DIFF
--- a/internal/logger/encoder.go
+++ b/internal/logger/encoder.go
@@ -1,0 +1,185 @@
+// Package logger provides custom logging utilities for the application.
+package logger
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+// PipeEncoder is a custom zapcore.Encoder that outputs fields in pipe-delimited format.
+// Instead of JSON format like {"key": "value"}, it outputs: key="value" | key=123
+type PipeEncoder struct {
+	zapcore.Encoder
+	pool      buffer.Pool
+	separator string
+	fields    []string
+}
+
+// NewPipeEncoder creates a new PipeEncoder with the specified separator.
+func NewPipeEncoder(separator string) *PipeEncoder {
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:          "time",
+		LevelKey:         "level",
+		NameKey:          "logger",
+		CallerKey:        "",
+		FunctionKey:      zapcore.OmitKey,
+		MessageKey:       "msg",
+		StacktraceKey:    "",
+		LineEnding:       zapcore.DefaultLineEnding,
+		EncodeLevel:      zapcore.CapitalLevelEncoder,
+		EncodeTime:       zapcore.ISO8601TimeEncoder,
+		EncodeDuration:   zapcore.StringDurationEncoder,
+		EncodeCaller:     zapcore.ShortCallerEncoder,
+		ConsoleSeparator: separator,
+	}
+
+	return &PipeEncoder{
+		Encoder:   zapcore.NewConsoleEncoder(encoderConfig),
+		pool:      buffer.NewPool(),
+		separator: separator,
+		fields:    make([]string, 0),
+	}
+}
+
+// Clone creates a copy of the encoder.
+func (e *PipeEncoder) Clone() zapcore.Encoder {
+	return &PipeEncoder{
+		Encoder:   e.Encoder.Clone(),
+		pool:      e.pool,
+		separator: e.separator,
+		fields:    append([]string{}, e.fields...),
+	}
+}
+
+// EncodeEntry encodes a log entry with pipe-delimited fields.
+func (e *PipeEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	// Create a clone to collect fields without modifying the original
+	clone := e.Clone().(*PipeEncoder)
+	clone.fields = make([]string, 0)
+
+	// Process each field to collect formatted strings
+	for _, field := range fields {
+		clone.addField(field)
+	}
+
+	// Encode the base entry (timestamp | LEVEL | message) without fields
+	buf, err := clone.Encoder.EncodeEntry(entry, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we have fields, append them in pipe-delimited format
+	if len(clone.fields) > 0 {
+		// Remove the trailing newline to append fields
+		content := buf.String()
+		content = strings.TrimSuffix(content, "\n")
+
+		// Create new buffer with fields appended
+		newBuf := e.pool.Get()
+		newBuf.AppendString(content)
+
+		for _, f := range clone.fields {
+			newBuf.AppendString(e.separator)
+			newBuf.AppendString(f)
+		}
+		newBuf.AppendString("\n")
+
+		buf.Free()
+		return newBuf, nil
+	}
+
+	return buf, nil
+}
+
+// addField processes a single field and adds it to the fields slice.
+func (e *PipeEncoder) addField(field zapcore.Field) {
+	switch field.Type {
+	case zapcore.StringType:
+		e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, field.String))
+
+	case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+		e.fields = append(e.fields, fmt.Sprintf("%s=%d", field.Key, field.Integer))
+
+	case zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
+		e.fields = append(e.fields, fmt.Sprintf("%s=%d", field.Key, field.Integer))
+
+	case zapcore.Float64Type:
+		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, float64(field.Integer)))
+
+	case zapcore.Float32Type:
+		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, float64(field.Integer)))
+
+	case zapcore.BoolType:
+		val := "false"
+		if field.Integer == 1 {
+			val = "true"
+		}
+		e.fields = append(e.fields, fmt.Sprintf("%s=%s", field.Key, val))
+
+	case zapcore.TimeType:
+		t := time.Unix(0, field.Integer)
+		if field.Interface != nil {
+			t = t.In(field.Interface.(*time.Location))
+		}
+		e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, t.Format(time.RFC3339)))
+
+	case zapcore.DurationType:
+		d := time.Duration(field.Integer)
+		e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, d.String()))
+
+	case zapcore.ErrorType:
+		if err, ok := field.Interface.(error); ok {
+			e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, err.Error()))
+		}
+
+	case zapcore.StringerType:
+		if stringer, ok := field.Interface.(fmt.Stringer); ok {
+			e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, stringer.String()))
+		}
+
+	default:
+		// For complex types, use the default string representation
+		if field.Interface != nil {
+			e.fields = append(e.fields, fmt.Sprintf("%s=%q", field.Key, fmt.Sprintf("%v", field.Interface)))
+		}
+	}
+}
+
+// NewPipeEncoderCore creates a zapcore.Core with the PipeEncoder.
+func NewPipeEncoderCore(level zapcore.Level) zapcore.Core {
+	encoder := NewPipeEncoder(" | ")
+	return zapcore.NewCore(
+		encoder,
+		zapcore.AddSync(zapcore.Lock(zapcore.AddSync(createStdoutSyncer()))),
+		level,
+	)
+}
+
+// createStdoutSyncer creates a write syncer for stdout.
+func createStdoutSyncer() zapcore.WriteSyncer {
+	return zapcore.AddSync(&stdoutWriter{})
+}
+
+// stdoutWriter is a simple writer that writes to stdout.
+type stdoutWriter struct{}
+
+func (w *stdoutWriter) Write(p []byte) (n int, err error) {
+	return fmt.Print(string(p))
+}
+
+// NewLogger creates a new zap.Logger with the PipeEncoder.
+func NewLogger() *zap.Logger {
+	core := NewPipeEncoderCore(zapcore.InfoLevel)
+	return zap.New(core)
+}
+
+// NewLoggerWithLevel creates a new zap.Logger with the PipeEncoder and specified level.
+func NewLoggerWithLevel(level zapcore.Level) *zap.Logger {
+	core := NewPipeEncoderCore(level)
+	return zap.New(core)
+}

--- a/internal/logger/encoder_test.go
+++ b/internal/logger/encoder_test.go
@@ -1,0 +1,199 @@
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// createTestLogger creates a logger that writes to a buffer for testing.
+func createTestLogger(buf *bytes.Buffer) *zap.Logger {
+	encoder := NewPipeEncoder(" | ")
+	core := zapcore.NewCore(
+		encoder,
+		zapcore.AddSync(buf),
+		zapcore.InfoLevel,
+	)
+	return zap.New(core)
+}
+
+func TestPipeEncoder_StringField(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Test message", zap.String("cluster", "production"))
+
+	output := buf.String()
+	assert.Contains(t, output, "INFO")
+	assert.Contains(t, output, "Test message")
+	assert.Contains(t, output, `cluster="production"`)
+}
+
+func TestPipeEncoder_IntField(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Test message", zap.Int("count", 42))
+
+	output := buf.String()
+	assert.Contains(t, output, "count=42")
+	assert.NotContains(t, output, `count="42"`) // Should NOT have quotes
+}
+
+func TestPipeEncoder_MultipleFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Filtering clusters",
+		zap.Int("matched", 1),
+		zap.Int("total", 19))
+
+	output := buf.String()
+	assert.Contains(t, output, "Filtering clusters")
+	assert.Contains(t, output, "matched=1")
+	assert.Contains(t, output, "total=19")
+	assert.Contains(t, output, " | matched=1")
+	assert.Contains(t, output, " | total=19")
+}
+
+func TestPipeEncoder_BoolField(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Test message",
+		zap.Bool("enabled", true),
+		zap.Bool("disabled", false))
+
+	output := buf.String()
+	assert.Contains(t, output, "enabled=true")
+	assert.Contains(t, output, "disabled=false")
+}
+
+func TestPipeEncoder_ErrorField(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	err := errors.New("connection timeout")
+	logger.Error("Failed to connect", zap.Error(err))
+
+	output := buf.String()
+	assert.Contains(t, output, "ERROR")
+	assert.Contains(t, output, "Failed to connect")
+	assert.Contains(t, output, `error="connection timeout"`)
+}
+
+func TestPipeEncoder_Float64Field(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Test message", zap.Float64("daysUntilExpiration", 15.5))
+
+	output := buf.String()
+	// Float should be formatted without quotes
+	assert.Contains(t, output, "daysUntilExpiration=")
+}
+
+func TestPipeEncoder_MixedFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Token status",
+		zap.String("cluster", "production"),
+		zap.Int("daysUntilExpiration", 15),
+		zap.Bool("needsRefresh", true))
+
+	output := buf.String()
+	assert.Contains(t, output, `cluster="production"`)
+	assert.Contains(t, output, "daysUntilExpiration=15")
+	assert.Contains(t, output, "needsRefresh=true")
+
+	// Verify pipe delimiter between fields
+	parts := strings.Split(output, " | ")
+	assert.GreaterOrEqual(t, len(parts), 4) // timestamp | level | message | fields...
+}
+
+func TestPipeEncoder_NoFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Simple message")
+
+	output := buf.String()
+	assert.Contains(t, output, "INFO")
+	assert.Contains(t, output, "Simple message")
+	// Should end with message, no trailing pipe
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	lastLine := lines[len(lines)-1]
+	assert.True(t, strings.HasSuffix(lastLine, "Simple message"),
+		"Expected line to end with message, got: %s", lastLine)
+}
+
+func TestPipeEncoder_DurationField(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Operation completed", zap.Duration("elapsed", 5*time.Second))
+
+	output := buf.String()
+	assert.Contains(t, output, "elapsed=")
+}
+
+func TestPipeEncoder_Clone(t *testing.T) {
+	encoder := NewPipeEncoder(" | ")
+	clone := encoder.Clone()
+
+	assert.NotNil(t, clone)
+	assert.IsType(t, &PipeEncoder{}, clone)
+}
+
+func TestPipeEncoder_FullLogFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("Filtering clusters based on --cluster flag",
+		zap.Int("matched", 1),
+		zap.Int("total", 19))
+
+	output := buf.String()
+
+	// Verify the expected format:
+	// timestamp | INFO | Filtering clusters based on --cluster flag | matched=1 | total=19
+	assert.Contains(t, output, " | INFO | ")
+	assert.Contains(t, output, "Filtering clusters based on --cluster flag")
+	assert.Contains(t, output, " | matched=1")
+	assert.Contains(t, output, " | total=19")
+
+	// Verify it does NOT contain JSON format
+	assert.NotContains(t, output, `{"matched"`)
+	assert.NotContains(t, output, `"total":`)
+}
+
+func TestPipeEncoder_DryRunPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	logger := createTestLogger(&buf)
+
+	logger.Info("[DRY-RUN] Would regenerate token",
+		zap.String("cluster", "production"),
+		zap.String("reason", "expires_soon"))
+
+	output := buf.String()
+	assert.Contains(t, output, "[DRY-RUN] Would regenerate token")
+	assert.Contains(t, output, `cluster="production"`)
+	assert.Contains(t, output, `reason="expires_soon"`)
+}
+
+func TestNewLogger(t *testing.T) {
+	logger := NewLogger()
+	assert.NotNil(t, logger)
+}
+
+func TestNewLoggerWithLevel(t *testing.T) {
+	logger := NewLoggerWithLevel(zapcore.DebugLevel)
+	assert.NotNil(t, logger)
+}


### PR DESCRIPTION
## Summary

- Implement custom `PipeEncoder` for consistent pipe-delimited log format
- Replace JSON field output with `key=value` format
- String values are quoted, numeric values are not

## Changes

### New `internal/logger` Package

Custom `zapcore.Encoder` implementation that formats structured fields as:
- Strings: `key="value"`
- Numbers: `key=123`
- Booleans: `key=true`
- Errors: `error="message"`

### Log Format Comparison

**Before:**
```
2026-01-31T10:00:00+0800 | INFO | Filtering clusters | {"matched": 1, "total": 19}
2026-01-31T10:00:01+0800 | INFO | Token regenerated | {"cluster": "production"}
```

**After:**
```
2026-01-31T10:00:00+0800 | INFO | Filtering clusters | matched=1 | total=19
2026-01-31T10:00:01+0800 | INFO | Token regenerated | cluster="production"
```

### Files Changed

| File | Description |
|------|-------------|
| `internal/logger/encoder.go` | PipeEncoder implementation |
| `internal/logger/encoder_test.go` | 14 test cases for encoder |
| `cmd/root.go` | Use new logger package |

## Test plan

- [x] All encoder tests pass (14 tests)
- [x] All existing tests pass
- [x] Pre-commit hooks pass (golangci-lint)
- [x] Pre-push hooks pass (test suite)

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
