### PR TITLE
fix: correct Float64/Float32 encoding in PipeEncoder

### DIFF
--- a/internal/logger/encoder.go
+++ b/internal/logger/encoder.go
@@ -3,6 +3,7 @@ package logger
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -109,10 +110,10 @@ func (e *PipeEncoder) addField(field zapcore.Field) {
 		e.fields = append(e.fields, fmt.Sprintf("%s=%d", field.Key, field.Integer))
 
 	case zapcore.Float64Type:
-		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, float64(field.Integer)))
+		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, math.Float64frombits(uint64(field.Integer))))
 
 	case zapcore.Float32Type:
-		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, float64(field.Integer)))
+		e.fields = append(e.fields, fmt.Sprintf("%s=%.2f", field.Key, math.Float32frombits(uint32(field.Integer))))
 
 	case zapcore.BoolType:
 		val := "false"

--- a/internal/logger/encoder_test.go
+++ b/internal/logger/encoder_test.go
@@ -95,8 +95,10 @@ func TestPipeEncoder_Float64Field(t *testing.T) {
 	logger.Info("Test message", zap.Float64("daysUntilExpiration", 15.5))
 
 	output := buf.String()
-	// Float should be formatted without quotes
-	assert.Contains(t, output, "daysUntilExpiration=")
+	// Float should be formatted without quotes and show correct value
+	assert.Contains(t, output, "daysUntilExpiration=15.50")
+	// Verify it does NOT contain the bug value (raw integer representation)
+	assert.NotContains(t, output, "4644421991715836928")
 }
 
 func TestPipeEncoder_MixedFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix Float64 and Float32 field encoding in custom PipeEncoder
- Values like `daysUntilExpiration` were displaying incorrectly (e.g., `4644421991715836928.00` instead of `15.50`)
- Root cause: `field.Integer` stores IEEE 754 bit representation, not the actual float value

## Changes

- Use `math.Float64frombits()` for Float64Type decoding
- Use `math.Float32frombits()` for Float32Type decoding
- Add stronger test assertion to verify correct float value output

## Test plan

- [x] Existing tests pass
- [x] Added assertion to verify `daysUntilExpiration=15.50` format
- [x] Added assertion to verify bug value is not present
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)