### PR TITLE
feat: add --with-directly flag for Downstream Directly support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 	thresholdDays         int
 	forceRefresh          bool
 	dryRun                bool
+	withDirectly          bool
 )
 
 func NewRootCmd() *cobra.Command {
@@ -45,6 +47,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().IntVar(&thresholdDays, "threshold-days", 30, "Expiration threshold in days")
 	rootCmd.Flags().BoolVar(&forceRefresh, "force-refresh", false, "Bypass expiration checks and force regeneration")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes without modifying kubeconfig")
+	rootCmd.Flags().BoolVar(&withDirectly, "with-directly", false, "Include Downstream Directly contexts for direct cluster access")
 
 	return rootCmd
 }
@@ -66,10 +69,16 @@ func run(cmd *cobra.Command, args []string) {
 	thresholdDays := config.GetInt(cmd, "threshold-days", "TOKEN_THRESHOLD_DAYS")
 	forceRefresh := config.GetBool(cmd, "force-refresh", "FORCE_REFRESH")
 	dryRun := config.GetBool(cmd, "dry-run", "DRY_RUN")
+	withDirectly := config.GetBool(cmd, "with-directly", "WITH_DIRECTLY")
 
 	// Log dry-run mode if enabled
 	if dryRun {
 		zapLogger.Info("[DRY-RUN] Mode enabled - no changes will be made to kubeconfig")
+	}
+
+	// Log with-directly mode if enabled
+	if withDirectly {
+		zapLogger.Info("Downstream Directly mode enabled - will include direct cluster contexts")
 	}
 
 	rancherPassword, err := config.GetPassword(cmd, "password", "RANCHER_PASSWORD")
@@ -147,14 +156,48 @@ func run(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		// Regenerate token
-		clusterToken := client.GetClusterToken(v.ID)
-		err = kubeconfig.UpdateTokenByName(kubecfg, v.ID, v.Name, clusterToken, rancherURL, autoCreate, zapLogger)
+		// Get full kubeconfig from Rancher (includes Downstream Directly contexts if available)
+		clusterKubeconfig, err := client.GetClusterKubeconfig(v.ID)
 		if err != nil {
-			// Error is already logged in UpdateTokenByName
+			zapLogger.Error("Failed to get kubeconfig for cluster",
+				zap.String("cluster", v.Name),
+				zap.Error(err))
 			continue
 		}
-		zapLogger.Info("Successfully updated kubeconfig token for cluster: " + v.Name)
+
+		// Check if we should use the new merge approach or legacy approach
+		if withDirectly || autoCreate {
+			// Use MergeKubeconfig for new approach (supports Downstream Directly)
+			kubeconfig.MergeKubeconfig(kubecfg, clusterKubeconfig, v.Name, withDirectly)
+			if withDirectly {
+				// Count direct contexts for logging
+				directCount := countDirectContexts(clusterKubeconfig, v.Name)
+				if directCount > 0 {
+					zapLogger.Info("Successfully updated kubeconfig with direct contexts",
+						zap.String("cluster", v.Name),
+						zap.Int("directContexts", directCount))
+				} else {
+					zapLogger.Info("Successfully updated kubeconfig token for cluster: " + v.Name)
+				}
+			} else {
+				zapLogger.Info("Successfully updated kubeconfig token for cluster: " + v.Name)
+			}
+		} else {
+			// Legacy approach: extract token and update only if user exists
+			var token string
+			for _, authInfo := range clusterKubeconfig.AuthInfos {
+				if authInfo.Token != "" {
+					token = authInfo.Token
+					break
+				}
+			}
+			err = kubeconfig.UpdateTokenByName(kubecfg, v.ID, v.Name, token, rancherURL, autoCreate, zapLogger)
+			if err != nil {
+				// Error is already logged in UpdateTokenByName
+				continue
+			}
+			zapLogger.Info("Successfully updated kubeconfig token for cluster: " + v.Name)
+		}
 	}
 
 	// Skip saving in dry-run mode and show summary
@@ -303,4 +346,17 @@ func filterClusters(clusters rancher.Clusters, clusterFilter string, logger *zap
 	}
 
 	return filteredClusters
+}
+
+// countDirectContexts counts the number of Downstream Directly contexts in a kubeconfig
+// Direct contexts are identified by having a name that starts with "{clusterName}-"
+func countDirectContexts(cfg *api.Config, clusterName string) int {
+	count := 0
+	prefix := clusterName + "-"
+	for ctxName := range cfg.Contexts {
+		if strings.HasPrefix(ctxName, prefix) {
+			count++
+		}
+	}
+	return count
 }

--- a/cmd/with_directly_integration_test.go
+++ b/cmd/with_directly_integration_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestCountDirectContexts tests the countDirectContexts helper function
+func TestCountDirectContexts(t *testing.T) {
+	tests := []struct {
+		name        string
+		contexts    map[string]*api.Context
+		clusterName string
+		expected    int
+	}{
+		{
+			name: "no direct contexts",
+			contexts: map[string]*api.Context{
+				"demo-cluster": {},
+			},
+			clusterName: "demo-cluster",
+			expected:    0,
+		},
+		{
+			name: "with direct contexts",
+			contexts: map[string]*api.Context{
+				"demo-cluster":        {},
+				"demo-cluster-node01": {},
+				"demo-cluster-node02": {},
+				"demo-cluster-node03": {},
+			},
+			clusterName: "demo-cluster",
+			expected:    3,
+		},
+		{
+			name: "mixed clusters",
+			contexts: map[string]*api.Context{
+				"prod":         {},
+				"prod-node01":  {},
+				"staging":      {},
+				"staging-fqdn": {},
+			},
+			clusterName: "prod",
+			expected:    1,
+		},
+		{
+			name: "no matching direct contexts",
+			contexts: map[string]*api.Context{
+				"demo-cluster": {},
+				"other-node01": {},
+				"another-fqdn": {},
+			},
+			clusterName: "demo-cluster",
+			expected:    0,
+		},
+		{
+			name: "pattern edge case - similar prefix",
+			contexts: map[string]*api.Context{
+				"prod":       {},
+				"prod-node":  {},
+				"production": {}, // Should NOT match
+			},
+			clusterName: "prod",
+			expected:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &api.Config{
+				Contexts: tt.contexts,
+			}
+			result := countDirectContexts(cfg, tt.clusterName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestCountDirectContexts_NilConfig tests handling of nil contexts map
+func TestCountDirectContexts_NilConfig(t *testing.T) {
+	cfg := &api.Config{
+		Contexts: nil,
+	}
+	result := countDirectContexts(cfg, "demo")
+	assert.Equal(t, 0, result)
+}
+
+// TestCountDirectContexts_EmptyConfig tests handling of empty contexts map
+func TestCountDirectContexts_EmptyConfig(t *testing.T) {
+	cfg := &api.Config{
+		Contexts: make(map[string]*api.Context),
+	}
+	result := countDirectContexts(cfg, "demo")
+	assert.Equal(t, 0, result)
+}

--- a/docs/plans/2025-01-31-with-directly-flag-design.md
+++ b/docs/plans/2025-01-31-with-directly-flag-design.md
@@ -1,0 +1,245 @@
+# Design: Add --with-directly Flag for Downstream Directly Context Import
+
+**Issue**: [#25](https://github.com/chenwei791129/rancher-kubeconfig-updater/issues/25)
+**Date**: 2025-01-31
+**Status**: Approved
+
+## Overview
+
+Add a new `--with-directly` flag that enables importing contexts using the "Downstream Directly" connection method provided by Rancher. This allows cluster operations to continue even when the Rancher server is unavailable.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Context handling | Merge mode | Include all direct contexts alongside proxy context |
+| Refactoring strategy | Modify existing function | Change `GetClusterToken()` to return `*api.Config` |
+| Conflict handling | Overwrite mode | Directly overwrite existing entries with same name |
+| Configuration | Flag + Environment variable | Support `--with-directly` and `WITH_DIRECTLY` env var |
+
+## Architecture
+
+### Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ cmd/root.go                                                             │
+│ ├─ Parse --with-directly flag / WITH_DIRECTLY env                       │
+│ └─ For each cluster:                                                    │
+│    ├─ client.GetClusterKubeconfig(clusterID)  ──────────────────┐       │
+│    └─ kubeconfig.MergeKubeconfig(target, source, name, withDir) │       │
+└─────────────────────────────────────────────────────────────────┼───────┘
+                                                                  │
+┌─────────────────────────────────────────────────────────────────┼───────┐
+│ internal/rancher/client.go                                      │       │
+│ GetClusterKubeconfig(clusterID) → *api.Config                   │       │
+│ ├─ POST /v3/clusters/{id}?action=generateKubeconfig             │       │
+│ ├─ Parse YAML response into *api.Config                         │       │
+│ └─ Return complete kubeconfig (includes direct contexts)  ◄─────┘       │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ internal/kubeconfig/manager.go                                          │
+│ MergeKubeconfig(target, source *api.Config, clusterName, withDirectly)  │
+│ ├─ Always merge primary context (exact match on clusterName)            │
+│ └─ If withDirectly=true, also merge contexts prefixed with clusterName- │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Kubeconfig Structure (Rancher Response)
+
+Example from `generateKubeconfig` API when Downstream Directly is enabled:
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- name: "demo-cluster"                    # Primary (Rancher proxy)
+  cluster:
+    server: "https://rancher.example.com/k8s/clusters/c-m-xxxxx"
+- name: "demo-cluster-node01"             # Direct access
+  cluster:
+    server: "https://192.168.1.101:6443"
+    certificate-authority-data: "LS0tLS..."
+- name: "demo-cluster-node02"             # Direct access
+  cluster:
+    server: "https://192.168.1.102:6443"
+    certificate-authority-data: "LS0tLS..."
+
+users:
+- name: "demo-cluster"                    # Shared user for all contexts
+  user:
+    token: "kubeconfig-user:xxxxx"
+
+contexts:
+- name: "demo-cluster"
+  context: {cluster: "demo-cluster", user: "demo-cluster"}
+- name: "demo-cluster-node01"
+  context: {cluster: "demo-cluster-node01", user: "demo-cluster"}
+- name: "demo-cluster-node02"
+  context: {cluster: "demo-cluster-node02", user: "demo-cluster"}
+```
+
+**Key observations:**
+- Direct context naming: `{clusterName}-{nodeHostname}`
+- All contexts share the same user (token)
+- Direct clusters have `certificate-authority-data`, primary does not
+- Node hostname comes from actual machine names
+
+## API Changes
+
+### GetClusterKubeconfig (Refactored from GetClusterToken)
+
+**File**: `internal/rancher/client.go`
+
+```go
+// GetClusterKubeconfig retrieves the full kubeconfig for a cluster
+// including Downstream Directly contexts if available.
+func (c *Client) GetClusterKubeconfig(clusterID string) (*api.Config, error) {
+    // POST /v3/clusters/{clusterID}?action=generateKubeconfig
+    // Parse response.config (YAML) into *api.Config
+    // Return the complete kubeconfig structure
+}
+```
+
+### MergeKubeconfig (New Function)
+
+**File**: `internal/kubeconfig/manager.go`
+
+```go
+// MergeKubeconfig merges source kubeconfig into target.
+// When withDirectly is true, includes all contexts (proxy + direct).
+// When withDirectly is false, only includes the primary proxy context.
+// Existing entries with the same name are overwritten.
+func MergeKubeconfig(target, source *api.Config, clusterName string, withDirectly bool) {
+    // 1. Always merge primary context (matches clusterName exactly)
+    //    - target.Clusters[clusterName] = source.Clusters[clusterName]
+    //    - target.Contexts[clusterName] = source.Contexts[clusterName]
+    //    - target.AuthInfos[clusterName] = source.AuthInfos[clusterName]
+
+    // 2. If withDirectly is true, also merge direct contexts:
+    //    - Contexts with prefix: {clusterName}-
+    //    - Their associated clusters and authInfos
+}
+```
+
+## CLI Changes
+
+### New Flag
+
+**File**: `cmd/root.go`
+
+```go
+var withDirectly bool
+
+rootCmd.Flags().BoolVar(&withDirectly, "with-directly", false,
+    "Include Downstream Directly contexts for direct cluster access")
+```
+
+### Configuration Priority
+
+```
+Flag (--with-directly) > Environment (WITH_DIRECTLY) > Default (false)
+```
+
+## Mock Server Extension
+
+### New Data Structures
+
+**File**: `internal/rancher/rancher_mock_test.go`
+
+```go
+// MockDirectNode represents a node for Downstream Directly access
+type MockDirectNode struct {
+    Hostname string // e.g., "node01", "master-1"
+    Server   string // e.g., "192.168.1.101:6443" or "k8s.internal.local:6443"
+}
+
+// MockClusterConfig holds cluster configuration for mock responses
+type MockClusterConfig struct {
+    ID              string
+    Name            string
+    DirectNodes     []MockDirectNode // Nodes for direct access
+    CACert          string           // CA certificate for direct clusters
+}
+
+// Option to configure clusters with Downstream Directly
+func WithClusterDirectly(clusterID, clusterName string, nodes []MockDirectNode, caCert string) MockServerOption
+```
+
+### Mock Response Example
+
+```yaml
+clusters:
+- name: "demo-cluster"
+  cluster:
+    server: "https://rancher.example.com/k8s/clusters/c-m-abcd1234"
+- name: "demo-cluster-node01"
+  cluster:
+    server: "https://192.168.1.101:6443"
+    certificate-authority-data: "bW9jay1jYS1jZXJ0LWRhdGEtZm9yLXRlc3Rpbmc="
+- name: "demo-cluster-node02"
+  cluster:
+    server: "https://192.168.1.102:6443"
+    certificate-authority-data: "bW9jay1jYS1jZXJ0LWRhdGEtZm9yLXRlc3Rpbmc="
+
+users:
+- name: "demo-cluster"
+  user:
+    token: "kubeconfig-user:mock-token-xxxxx"
+
+contexts:
+- name: "demo-cluster"
+  context: {cluster: "demo-cluster", user: "demo-cluster"}
+- name: "demo-cluster-node01"
+  context: {cluster: "demo-cluster-node01", user: "demo-cluster"}
+- name: "demo-cluster-node02"
+  context: {cluster: "demo-cluster-node02", user: "demo-cluster"}
+```
+
+## Test Plan
+
+### Unit Tests
+
+**File**: `internal/rancher/client_test.go`
+- `TestGetClusterKubeconfig_WithDirectly` - Verify returned config includes all contexts
+- `TestGetClusterKubeconfig_WithoutDirectly` - Verify only primary context when no direct nodes
+
+**File**: `internal/kubeconfig/manager_test.go`
+- `TestMergeKubeconfig_WithDirectlyEnabled` - Verify all contexts merged
+- `TestMergeKubeconfig_WithDirectlyDisabled` - Verify only primary context merged
+- `TestMergeKubeconfig_OverwriteExisting` - Verify overwrite behavior
+
+### Integration Tests
+
+**File**: `cmd/with_directly_integration_test.go`
+- `TestWithDirectlyFlag_Enabled` - End-to-end with mock server
+- `TestWithDirectlyFlag_Disabled` - Verify direct contexts excluded
+- `TestWithDirectlyFlag_EnvVar` - Verify environment variable works
+
+## Implementation Plan
+
+| Phase | Description | Files |
+|-------|-------------|-------|
+| 1 | Mock Server extension | `internal/rancher/rancher_mock_test.go` |
+| 2 | API layer refactoring | `internal/rancher/client.go` |
+| 3 | Kubeconfig merge logic | `internal/kubeconfig/manager.go` |
+| 4 | CLI integration | `cmd/root.go` |
+| 5 | Tests | `*_test.go` files |
+
+## File Changes Summary
+
+| File | Change Type |
+|------|-------------|
+| `internal/rancher/rancher_mock_test.go` | Modify |
+| `internal/rancher/client.go` | Modify |
+| `internal/kubeconfig/manager.go` | Modify |
+| `cmd/root.go` | Modify |
+| `internal/rancher/client_test.go` | Add/Modify |
+| `internal/kubeconfig/manager_test.go` | Add/Modify |
+| `cmd/with_directly_integration_test.go` | Add |
+
+## References
+
+- [Rancher: Authenticating Directly with a Downstream Cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#authenticating-directly-with-a-downstream-cluster)
+- [Issue #25 Research Comment](https://github.com/chenwei791129/rancher-kubeconfig-updater/issues/25#issuecomment-3675670020)

--- a/internal/kubeconfig/kubeconfig_test.go
+++ b/internal/kubeconfig/kubeconfig_test.go
@@ -1004,13 +1004,13 @@ func TestLoadKubeconfig_WithKUBECONFIG_SingleFile(t *testing.T) {
 
 	// Set KUBECONFIG environment variable
 	t.Setenv("KUBECONFIG", kubeconfigFile)
-	
+
 	// Load with empty path (should use KUBECONFIG)
 	config, err := LoadKubeconfig("")
 	if err != nil {
 		t.Fatalf("LoadKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify structure
 	if len(config.Clusters) != 1 {
 		t.Errorf("Expected 1 cluster, got %d", len(config.Clusters))
@@ -1025,12 +1025,12 @@ func TestLoadKubeconfig_WithKUBECONFIG_MultipleFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "config1")
 	file2 := filepath.Join(tmpDir, "config2")
-	
+
 	// Create first config file
 	if err := os.WriteFile(file1, []byte(createTestKubeconfigContent()), 0600); err != nil {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
-	
+
 	// Create second config file (doesn't exist yet)
 	// According to kubectl behavior, when multiple files are specified:
 	// - For reading: merge all files
@@ -1039,13 +1039,13 @@ func TestLoadKubeconfig_WithKUBECONFIG_MultipleFiles(t *testing.T) {
 	// Set KUBECONFIG with multiple files (OS-specific path separator)
 	separator := string(os.PathListSeparator)
 	t.Setenv("KUBECONFIG", file1+separator+file2)
-	
+
 	// Load with empty path (should use first file from KUBECONFIG)
 	config, err := LoadKubeconfig("")
 	if err != nil {
 		t.Fatalf("LoadKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify structure loaded from first file
 	if len(config.Clusters) != 1 {
 		t.Errorf("Expected 1 cluster, got %d", len(config.Clusters))
@@ -1059,20 +1059,20 @@ func TestSaveKubeconfig_WithKUBECONFIG_SingleFile(t *testing.T) {
 
 	// Set KUBECONFIG environment variable
 	t.Setenv("KUBECONFIG", kubeconfigFile)
-	
+
 	config := createTestKubeconfig()
-	
+
 	// Save with empty path (should use KUBECONFIG)
 	err := SaveKubeconfig(config, "", nil)
 	if err != nil {
 		t.Fatalf("SaveKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify file was created at KUBECONFIG location
 	if _, err := os.Stat(kubeconfigFile); os.IsNotExist(err) {
 		t.Error("SaveKubeconfig() did not create file at KUBECONFIG location")
 	}
-	
+
 	// Verify content
 	loaded, err := LoadKubeconfig("")
 	if err != nil {
@@ -1088,7 +1088,7 @@ func TestSaveKubeconfig_WithKUBECONFIG_MultipleFiles_FirstExists(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "config1")
 	file2 := filepath.Join(tmpDir, "config2")
-	
+
 	// Create first file (existing)
 	if err := os.WriteFile(file1, []byte(createTestKubeconfigContent()), 0600); err != nil {
 		t.Fatalf("Failed to write test file: %v", err)
@@ -1097,16 +1097,16 @@ func TestSaveKubeconfig_WithKUBECONFIG_MultipleFiles_FirstExists(t *testing.T) {
 	// Set KUBECONFIG with multiple files
 	separator := string(os.PathListSeparator)
 	t.Setenv("KUBECONFIG", file1+separator+file2)
-	
+
 	config := createTestKubeconfig()
 	config.AuthInfos["test-cluster"].Token = "new-token"
-	
+
 	// Save with empty path (should use first existing file)
 	err := SaveKubeconfig(config, "", nil)
 	if err != nil {
 		t.Fatalf("SaveKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify first file was updated
 	loaded, err := LoadKubeconfig(file1)
 	if err != nil {
@@ -1115,7 +1115,7 @@ func TestSaveKubeconfig_WithKUBECONFIG_MultipleFiles_FirstExists(t *testing.T) {
 	if loaded.AuthInfos["test-cluster"].Token != "new-token" {
 		t.Error("First file should be updated")
 	}
-	
+
 	// Verify second file was not created
 	if _, err := os.Stat(file2); !os.IsNotExist(err) {
 		t.Error("Second file should not be created when first file exists")
@@ -1127,21 +1127,21 @@ func TestSaveKubeconfig_WithKUBECONFIG_MultipleFiles_NoneExist(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "config1")
 	file2 := filepath.Join(tmpDir, "config2")
-	
+
 	// Neither file exists yet
 
 	// Set KUBECONFIG with multiple files
 	separator := string(os.PathListSeparator)
 	t.Setenv("KUBECONFIG", file1+separator+file2)
-	
+
 	config := createTestKubeconfig()
-	
+
 	// Save with empty path
 	err := SaveKubeconfig(config, "", nil)
 	if err != nil {
 		t.Fatalf("SaveKubeconfig() error = %v", err)
 	}
-	
+
 	// Note: ClientConfigLoadingRules.GetDefaultFilename() returns the first file when none exist.
 	// This differs from kubectl's PathOptions.GetDefaultFilename() which returns the last file.
 	// We use ClientConfigLoadingRules because:
@@ -1165,13 +1165,13 @@ func TestLoadKubeconfig_ExplicitPathOverridesKUBECONFIG(t *testing.T) {
 	tmpDir := t.TempDir()
 	kubeconfigFile := filepath.Join(tmpDir, "env-config")
 	explicitFile := filepath.Join(tmpDir, "explicit-config")
-	
+
 	// Create both files with different content
 	content1 := createTestKubeconfigContent()
 	if err := os.WriteFile(kubeconfigFile, []byte(content1), 0600); err != nil {
 		t.Fatalf("Failed to write env config: %v", err)
 	}
-	
+
 	// Create explicit file with different token
 	config2 := createTestKubeconfig()
 	config2.AuthInfos["test-cluster"].Token = "explicit-token"
@@ -1181,13 +1181,13 @@ func TestLoadKubeconfig_ExplicitPathOverridesKUBECONFIG(t *testing.T) {
 
 	// Set KUBECONFIG environment variable
 	t.Setenv("KUBECONFIG", kubeconfigFile)
-	
+
 	// Load with explicit path (should ignore KUBECONFIG)
 	config, err := LoadKubeconfig(explicitFile)
 	if err != nil {
 		t.Fatalf("LoadKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify we loaded from explicit file, not KUBECONFIG
 	if config.AuthInfos["test-cluster"].Token != "explicit-token" {
 		t.Errorf("Expected explicit-token, got %s", config.AuthInfos["test-cluster"].Token)
@@ -1202,20 +1202,20 @@ func TestSaveKubeconfig_ExplicitPathOverridesKUBECONFIG(t *testing.T) {
 
 	// Set KUBECONFIG environment variable
 	t.Setenv("KUBECONFIG", kubeconfigFile)
-	
+
 	config := createTestKubeconfig()
-	
+
 	// Save with explicit path (should ignore KUBECONFIG)
 	err := SaveKubeconfig(config, explicitFile, nil)
 	if err != nil {
 		t.Fatalf("SaveKubeconfig() error = %v", err)
 	}
-	
+
 	// Verify file was created at explicit location
 	if _, err := os.Stat(explicitFile); os.IsNotExist(err) {
 		t.Error("SaveKubeconfig() should create file at explicit path")
 	}
-	
+
 	// Verify KUBECONFIG file was not created
 	if _, err := os.Stat(kubeconfigFile); !os.IsNotExist(err) {
 		t.Error("SaveKubeconfig() should not create file at KUBECONFIG location when explicit path provided")
@@ -1261,5 +1261,287 @@ func TestLoadKubeconfig_EmptyKUBECONFIG_UsesDefault(t *testing.T) {
 	// Should return empty config if default doesn't exist, or loaded config if it does
 	if config == nil {
 		t.Error("LoadKubeconfig() should return a config structure")
+	}
+}
+
+// ============================================================================
+// MergeKubeconfig Tests
+// ============================================================================
+
+// createTestSourceKubeconfig creates a source kubeconfig with direct contexts
+func createTestSourceKubeconfig() *api.Config {
+	config := api.NewConfig()
+
+	// Primary cluster
+	config.Clusters["demo-cluster"] = &api.Cluster{
+		Server: "https://rancher.example.com/k8s/clusters/c-m-demo",
+	}
+
+	// Direct clusters
+	config.Clusters["demo-cluster-node01"] = &api.Cluster{
+		Server:                   "https://192.168.1.101:6443",
+		CertificateAuthorityData: []byte("test-ca-data"),
+	}
+	config.Clusters["demo-cluster-node02"] = &api.Cluster{
+		Server:                   "https://192.168.1.102:6443",
+		CertificateAuthorityData: []byte("test-ca-data"),
+	}
+
+	// Primary context
+	config.Contexts["demo-cluster"] = &api.Context{
+		Cluster:  "demo-cluster",
+		AuthInfo: "demo-cluster",
+	}
+
+	// Direct contexts
+	config.Contexts["demo-cluster-node01"] = &api.Context{
+		Cluster:  "demo-cluster-node01",
+		AuthInfo: "demo-cluster",
+	}
+	config.Contexts["demo-cluster-node02"] = &api.Context{
+		Cluster:  "demo-cluster-node02",
+		AuthInfo: "demo-cluster",
+	}
+
+	// User (shared by all contexts)
+	config.AuthInfos["demo-cluster"] = &api.AuthInfo{
+		Token: "kubeconfig-user:demo-token",
+	}
+
+	config.CurrentContext = "demo-cluster"
+
+	return config
+}
+
+// TestMergeKubeconfig_WithDirectlyEnabled tests merging all contexts
+func TestMergeKubeconfig_WithDirectlyEnabled(t *testing.T) {
+	target := api.NewConfig()
+	source := createTestSourceKubeconfig()
+
+	MergeKubeconfig(target, source, "demo-cluster", true)
+
+	// Verify all clusters were merged
+	if len(target.Clusters) != 3 {
+		t.Errorf("Expected 3 clusters, got %d", len(target.Clusters))
+	}
+	if target.Clusters["demo-cluster"] == nil {
+		t.Error("Primary cluster should be merged")
+	}
+	if target.Clusters["demo-cluster-node01"] == nil {
+		t.Error("Direct cluster node01 should be merged")
+	}
+	if target.Clusters["demo-cluster-node02"] == nil {
+		t.Error("Direct cluster node02 should be merged")
+	}
+
+	// Verify all contexts were merged
+	if len(target.Contexts) != 3 {
+		t.Errorf("Expected 3 contexts, got %d", len(target.Contexts))
+	}
+
+	// Verify authInfo was merged
+	if len(target.AuthInfos) != 1 {
+		t.Errorf("Expected 1 authInfo (shared), got %d", len(target.AuthInfos))
+	}
+	if target.AuthInfos["demo-cluster"] == nil {
+		t.Error("AuthInfo should be merged")
+	}
+	if target.AuthInfos["demo-cluster"].Token != "kubeconfig-user:demo-token" {
+		t.Errorf("Expected token kubeconfig-user:demo-token, got %s", target.AuthInfos["demo-cluster"].Token)
+	}
+}
+
+// TestMergeKubeconfig_WithDirectlyDisabled tests merging only primary context
+func TestMergeKubeconfig_WithDirectlyDisabled(t *testing.T) {
+	target := api.NewConfig()
+	source := createTestSourceKubeconfig()
+
+	MergeKubeconfig(target, source, "demo-cluster", false)
+
+	// Verify only primary cluster was merged
+	if len(target.Clusters) != 1 {
+		t.Errorf("Expected 1 cluster, got %d", len(target.Clusters))
+	}
+	if target.Clusters["demo-cluster"] == nil {
+		t.Error("Primary cluster should be merged")
+	}
+	if target.Clusters["demo-cluster-node01"] != nil {
+		t.Error("Direct cluster node01 should NOT be merged")
+	}
+	if target.Clusters["demo-cluster-node02"] != nil {
+		t.Error("Direct cluster node02 should NOT be merged")
+	}
+
+	// Verify only primary context was merged
+	if len(target.Contexts) != 1 {
+		t.Errorf("Expected 1 context, got %d", len(target.Contexts))
+	}
+	if target.Contexts["demo-cluster"] == nil {
+		t.Error("Primary context should be merged")
+	}
+
+	// Verify authInfo was merged
+	if len(target.AuthInfos) != 1 {
+		t.Errorf("Expected 1 authInfo, got %d", len(target.AuthInfos))
+	}
+}
+
+// TestMergeKubeconfig_OverwriteExisting tests overwrite behavior
+func TestMergeKubeconfig_OverwriteExisting(t *testing.T) {
+	// Create target with existing entries
+	target := api.NewConfig()
+	target.Clusters["demo-cluster"] = &api.Cluster{
+		Server: "https://old-server.example.com",
+	}
+	target.Contexts["demo-cluster"] = &api.Context{
+		Cluster:  "demo-cluster",
+		AuthInfo: "demo-cluster",
+	}
+	target.AuthInfos["demo-cluster"] = &api.AuthInfo{
+		Token: "old-token",
+	}
+
+	// Create source with new values
+	source := createTestSourceKubeconfig()
+
+	MergeKubeconfig(target, source, "demo-cluster", false)
+
+	// Verify values were overwritten
+	if target.Clusters["demo-cluster"].Server != "https://rancher.example.com/k8s/clusters/c-m-demo" {
+		t.Errorf("Cluster server should be overwritten, got %s", target.Clusters["demo-cluster"].Server)
+	}
+	if target.AuthInfos["demo-cluster"].Token != "kubeconfig-user:demo-token" {
+		t.Errorf("Token should be overwritten, got %s", target.AuthInfos["demo-cluster"].Token)
+	}
+}
+
+// TestMergeKubeconfig_PreservesOtherEntries tests that other entries are preserved
+func TestMergeKubeconfig_PreservesOtherEntries(t *testing.T) {
+	// Create target with existing entries from different cluster
+	target := api.NewConfig()
+	target.Clusters["other-cluster"] = &api.Cluster{
+		Server: "https://other-server.example.com",
+	}
+	target.Contexts["other-cluster"] = &api.Context{
+		Cluster:  "other-cluster",
+		AuthInfo: "other-cluster",
+	}
+	target.AuthInfos["other-cluster"] = &api.AuthInfo{
+		Token: "other-token",
+	}
+
+	source := createTestSourceKubeconfig()
+
+	MergeKubeconfig(target, source, "demo-cluster", true)
+
+	// Verify other entries are preserved
+	if target.Clusters["other-cluster"] == nil {
+		t.Error("Other cluster should be preserved")
+	}
+	if target.Clusters["other-cluster"].Server != "https://other-server.example.com" {
+		t.Error("Other cluster server should not change")
+	}
+	if target.AuthInfos["other-cluster"] == nil {
+		t.Error("Other authInfo should be preserved")
+	}
+	if target.AuthInfos["other-cluster"].Token != "other-token" {
+		t.Error("Other token should not change")
+	}
+
+	// Verify new entries are added
+	if target.Clusters["demo-cluster"] == nil {
+		t.Error("Demo cluster should be added")
+	}
+
+	// Total should be 4 clusters (1 other + 3 from source)
+	if len(target.Clusters) != 4 {
+		t.Errorf("Expected 4 clusters, got %d", len(target.Clusters))
+	}
+}
+
+// TestMergeKubeconfig_NilMaps tests handling of nil maps in target
+func TestMergeKubeconfig_NilMaps(t *testing.T) {
+	// Create target with nil maps (as returned by api.NewConfig() doesn't initialize maps as nil)
+	target := &api.Config{
+		Clusters:  nil,
+		Contexts:  nil,
+		AuthInfos: nil,
+	}
+
+	source := createTestSourceKubeconfig()
+
+	// Should not panic
+	MergeKubeconfig(target, source, "demo-cluster", true)
+
+	// Verify maps were initialized and entries added
+	if target.Clusters == nil {
+		t.Error("Clusters map should be initialized")
+	}
+	if target.Contexts == nil {
+		t.Error("Contexts map should be initialized")
+	}
+	if target.AuthInfos == nil {
+		t.Error("AuthInfos map should be initialized")
+	}
+
+	if len(target.Clusters) != 3 {
+		t.Errorf("Expected 3 clusters, got %d", len(target.Clusters))
+	}
+}
+
+// TestMergeKubeconfig_EmptySource tests handling of empty source
+func TestMergeKubeconfig_EmptySource(t *testing.T) {
+	target := createTestKubeconfig()
+	source := api.NewConfig()
+
+	originalClusters := len(target.Clusters)
+
+	MergeKubeconfig(target, source, "nonexistent", true)
+
+	// Target should be unchanged
+	if len(target.Clusters) != originalClusters {
+		t.Errorf("Target clusters should be unchanged, expected %d, got %d", originalClusters, len(target.Clusters))
+	}
+}
+
+// TestMergeKubeconfig_DirectContextPatternMatching tests correct pattern matching for direct contexts
+func TestMergeKubeconfig_DirectContextPatternMatching(t *testing.T) {
+	target := api.NewConfig()
+
+	// Create source with various context names
+	source := api.NewConfig()
+	source.Clusters["prod"] = &api.Cluster{Server: "https://prod.example.com"}
+	source.Clusters["prod-node1"] = &api.Cluster{Server: "https://prod-node1.example.com"}
+	source.Clusters["production"] = &api.Cluster{Server: "https://production.example.com"} // Should NOT match
+	source.Clusters["prod-"] = &api.Cluster{Server: "https://prod-.example.com"}           // Edge case
+
+	source.Contexts["prod"] = &api.Context{Cluster: "prod", AuthInfo: "prod"}
+	source.Contexts["prod-node1"] = &api.Context{Cluster: "prod-node1", AuthInfo: "prod"}
+	source.Contexts["production"] = &api.Context{Cluster: "production", AuthInfo: "production"} // Different user
+	source.Contexts["prod-"] = &api.Context{Cluster: "prod-", AuthInfo: "prod"}
+
+	source.AuthInfos["prod"] = &api.AuthInfo{Token: "prod-token"}
+	source.AuthInfos["production"] = &api.AuthInfo{Token: "production-token"}
+
+	MergeKubeconfig(target, source, "prod", true)
+
+	// Should match: prod, prod-node1, prod-
+	// Should NOT match: production (doesn't start with "prod-")
+	if target.Contexts["prod"] == nil {
+		t.Error("Primary context 'prod' should be merged")
+	}
+	if target.Contexts["prod-node1"] == nil {
+		t.Error("Direct context 'prod-node1' should be merged")
+	}
+	if target.Contexts["prod-"] == nil {
+		t.Error("Direct context 'prod-' should be merged")
+	}
+	if target.Contexts["production"] != nil {
+		t.Error("Context 'production' should NOT be merged (doesn't match pattern)")
+	}
+
+	// Verify correct count
+	if len(target.Contexts) != 3 {
+		t.Errorf("Expected 3 contexts, got %d", len(target.Contexts))
 	}
 }

--- a/internal/kubeconfig/manager.go
+++ b/internal/kubeconfig/manager.go
@@ -40,7 +40,7 @@ func LoadKubeconfig(path string) (*api.Config, error) {
 		}
 		loadingRules.ExplicitPath = expandedPath
 	}
-	
+
 	// Get the actual file path we'll use (respects KUBECONFIG, precedence, etc.)
 	targetPath := loadingRules.GetDefaultFilename()
 
@@ -105,6 +105,50 @@ func UpdateTokenByName(c *api.Config, clusterID, clusterName, token, rancherURL 
 	return fmt.Errorf("user %s not found in kubeconfig", clusterName)
 }
 
+// MergeKubeconfig merges source kubeconfig into target for a specific cluster.
+// When withDirectly is true, includes all contexts (proxy + Downstream Directly).
+// When withDirectly is false, only includes the primary proxy context.
+// Existing entries with the same name are overwritten.
+//
+// The function identifies direct contexts by checking if the context name
+// starts with "{clusterName}-" prefix.
+func MergeKubeconfig(target, source *api.Config, clusterName string, withDirectly bool) {
+	// Initialize maps if nil
+	if target.Clusters == nil {
+		target.Clusters = make(map[string]*api.Cluster)
+	}
+	if target.Contexts == nil {
+		target.Contexts = make(map[string]*api.Context)
+	}
+	if target.AuthInfos == nil {
+		target.AuthInfos = make(map[string]*api.AuthInfo)
+	}
+
+	// Determine which contexts to merge
+	directPrefix := clusterName + "-"
+
+	for ctxName, ctx := range source.Contexts {
+		// Check if this context should be merged
+		isPrimary := ctxName == clusterName
+		isDirect := strings.HasPrefix(ctxName, directPrefix)
+
+		if isPrimary || (withDirectly && isDirect) {
+			// Merge context
+			target.Contexts[ctxName] = ctx
+
+			// Merge associated cluster
+			if cluster, exists := source.Clusters[ctx.Cluster]; exists {
+				target.Clusters[ctx.Cluster] = cluster
+			}
+
+			// Merge associated authInfo
+			if authInfo, exists := source.AuthInfos[ctx.AuthInfo]; exists {
+				target.AuthInfos[ctx.AuthInfo] = authInfo
+			}
+		}
+	}
+}
+
 // SaveKubeconfig saves a kubeconfig file using the following precedence order:
 //  1. Explicit path parameter (if provided) - highest priority
 //  2. KUBECONFIG environment variable (if set) - handles multiple files
@@ -132,7 +176,7 @@ func SaveKubeconfig(c *api.Config, path string, logger *zap.Logger) error {
 		}
 		loadingRules.ExplicitPath = expandedPath
 	}
-	
+
 	// Get the actual file path we'll use (respects KUBECONFIG, precedence, etc.)
 	targetPath := loadingRules.GetDefaultFilename()
 


### PR DESCRIPTION
## Summary

Implements support for Rancher's "Downstream Directly" connection method, allowing users to import kubeconfig contexts for direct cluster access (bypassing Rancher proxy).

- Add `--with-directly` flag and `WITH_DIRECTLY` environment variable
- Refactor API layer to return full kubeconfig instead of just token
- Add `MergeKubeconfig` function for selective context merging
- Extend Mock Rancher Server to support Downstream Directly testing

Closes #25

## Changes

### API Layer (`internal/rancher/client.go`)
- Add `GetClusterKubeconfig()` to return full `*api.Config` instead of just token
- Keep `GetClusterToken()` as convenience method

### Kubeconfig Manager (`internal/kubeconfig/manager.go`)
- Add `MergeKubeconfig()` function that merges source kubeconfig into target
- Supports selective merging: primary context only, or primary + direct contexts

### CLI Integration (`cmd/root.go`)
- Add `--with-directly` flag with `WITH_DIRECTLY` env var support
- Integrate with new merge workflow when flag is enabled
- Add `countDirectContexts()` helper for logging

### Mock Server (`internal/rancher/rancher_mock_test.go`)
- Add `MockDirectNode` and `MockClusterConfig` types
- Add `WithClusterDirectly()` option to configure mock responses
- Support generating kubeconfig YAML with direct contexts

## Test Plan

- [x] Unit tests for `MergeKubeconfig` function
- [x] Unit tests for `GetClusterKubeconfig` API method
- [x] Unit tests for `countDirectContexts` helper
- [x] Mock server tests for Downstream Directly responses
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)
